### PR TITLE
Fix frameskip in gym environment

### DIFF
--- a/malmopy/environment/gym/gym.py
+++ b/malmopy/environment/gym/gym.py
@@ -48,7 +48,7 @@ class GymEnvironment(VideoCapableEnvironment):
 
         self._state_builder = state_builder
         self._env = gym.make(env_name)
-        self._env.frameskip = repeat_action
+        self._env.env.frameskip = repeat_action
         self._no_op = max(0, no_op)
         self._done = True
 

--- a/malmopy/model/chainer/qlearning.py
+++ b/malmopy/model/chainer/qlearning.py
@@ -214,7 +214,7 @@ class QNeuralNetwork(QModel):
         q_subset = F.reshape(F.select_item(q, actions), (batch_size, 1))
         y = y.reshape(batch_size, 1)
 
-        loss = F.huber_loss(q_subset, y, 1.0)
+        loss = F.sum(F.huber_loss(q_subset, y, 1.0))
 
         self._model.cleargrads()
         loss.backward()


### PR DESCRIPTION
We set skip frame in a env parent and it was not used when doing env.step. Hence the default parameters with sampling from {2,3,4...} were used.