### PR TITLE
Reduce memory footprint for python2 by using range iterator

### DIFF
--- a/ai_challenge/pig_chase/pig_chase_baseline.py
+++ b/ai_challenge/pig_chase/pig_chase_baseline.py
@@ -21,6 +21,8 @@ import sys
 
 from argparse import ArgumentParser
 from datetime import datetime
+
+import six
 from os import path
 from threading import Thread, active_count
 from time import sleep
@@ -97,7 +99,7 @@ def agent_factory(name, role, baseline_agent, clients, max_epochs,
         viz_rewards = []
 
         max_training_steps = EPOCH_SIZE * max_epochs
-        for step in range(1, max_training_steps+1):
+        for step in six.moves.range(1, max_training_steps+1):
 
             # check if env needs reset
             if env.done:

--- a/ai_challenge/pig_chase/pig_chase_dqn.py
+++ b/ai_challenge/pig_chase/pig_chase_dqn.py
@@ -19,6 +19,8 @@ import os
 import sys
 from argparse import ArgumentParser
 from datetime import datetime
+
+import six
 from os import path
 from threading import Thread, active_count
 from time import sleep
@@ -112,7 +114,7 @@ def agent_factory(name, role, clients, backend,
         viz_rewards = []
 
         max_training_steps = EPOCH_SIZE * max_epochs
-        for step in range(1, max_training_steps+1):
+        for step in six.moves.range(1, max_training_steps+1):
 
             # check if env needs reset
             if env.done:

--- a/ai_challenge/pig_chase/pig_chase_dqn_top_down.py
+++ b/ai_challenge/pig_chase/pig_chase_dqn_top_down.py
@@ -19,6 +19,8 @@ import os
 import sys
 from argparse import ArgumentParser
 from datetime import datetime
+
+import six
 from os import path
 from threading import Thread, active_count
 from time import sleep
@@ -112,7 +114,7 @@ def agent_factory(name, role, clients, backend, device, max_epochs, logdir, visu
         viz_rewards = []
 
         max_training_steps = EPOCH_SIZE * max_epochs
-        for step in range(1, max_training_steps+1):
+        for step in six.moves.range(1, max_training_steps+1):
 
             # check if env needs reset
             if env.done:


### PR DESCRIPTION
DQN & co. use range() for looping which throws MemoryError on Python 2. This PR moves range to six.moves.range() to behave as an iterator.